### PR TITLE
feat: Remove metamask from autowallet (#772)

### DIFF
--- a/.jest/__mocks__/hooksMocks.ts
+++ b/.jest/__mocks__/hooksMocks.ts
@@ -16,13 +16,20 @@ jest.mock('../../../@context/Asset', () => ({
   useAsset: () => ({ asset })
 }))
 
-jest.mock('wagmi', () => ({
-  useNetwork: () => ({ network }),
-  useSwitchNetwork: () => ({ switchNetwork: () => jest.fn() }),
-  useProvider: () => jest.fn(),
-  createClient: () => jest.fn(),
-  configureChains: () => jest.fn()
-}))
+jest.mock('wagmi', () => {
+  // Get the original wagmi module to also include Connector
+  const originalModule = jest.requireActual('wagmi')
+
+  return {
+    ...originalModule,
+    // override specific hooks
+    useNetwork: () => ({ network }),
+    useSwitchNetwork: () => ({ switchNetwork: () => jest.fn() }),
+    useProvider: () => jest.fn(),
+    createClient: () => jest.fn(),
+    configureChains: () => jest.fn()
+  }
+})
 
 jest.mock('../../@context/SearchBarStatus', () => ({
   useSearchBarStatus: () => searchBarStatus

--- a/app.config.js
+++ b/app.config.js
@@ -120,6 +120,9 @@ module.exports = {
   showOnboardingModuleByDefault:
     process.env.NEXT_PUBLIC_SHOW_ONBOARDING_MODULE_BY_DEFAULT === 'true',
 
+  // hides MetaMask Connect Wallet button
+  hideMetaMaskLogin: process.env.NEXT_PUBLIC_HIDE_METAMASK_LOGIN || 'false',
+
   allowedGaiaXRegistryDomains: [
     'https://registry.gaia-x.eu/v2206',
     'https://registry.lab.gaia-x.eu/v2206'

--- a/src/@utils/faucet/index.ts
+++ b/src/@utils/faucet/index.ts
@@ -29,23 +29,16 @@ export async function getMessage(address: string): Promise<string> {
   }
 }
 
-export async function getChainId(): Promise<number> {
-  const network = await new ethers.providers.Web3Provider(
-    window?.ethereum
-  ).getNetwork()
-  return network.chainId
-}
-
 export async function requestTokens(
   address: string,
-  signature: string
+  signature: string,
+  chainId: number
 ): Promise<string[]> {
   try {
     const availableNetworks = {
       32456: 'devnet',
       32457: 'testnet'
     }
-    const chainId = await getChainId()
     const network = availableNetworks[chainId]
 
     const response = await axios.post<{

--- a/src/@utils/wallet/EthersWalletConnector.ts
+++ b/src/@utils/wallet/EthersWalletConnector.ts
@@ -1,0 +1,220 @@
+import { Connector, Chain, UserRejectedRequestError } from 'wagmi'
+import { ethers, Wallet } from 'ethers'
+import { getOceanConfig } from '@utils/ocean'
+import { LoggerInstance } from '@oceanprotocol/lib'
+
+export const JSON_WALLET_CONNECTOR_ID = 'jsonWallet'
+
+export class EthersWalletConnector extends Connector {
+  readonly id = JSON_WALLET_CONNECTOR_ID
+  readonly name = 'JSON Wallet'
+  readonly ready: boolean
+
+  #provider?: ethers.providers.JsonRpcProvider
+  #wallet?: Wallet
+
+  constructor({ chains, options }: { chains?: Chain[]; options?: unknown }) {
+    super({ chains, options })
+    this.ready = true
+    LoggerInstance.log('[EthersWalletConnector] Connector initialized.')
+  }
+
+  /**
+   * Public method to load the wallet from a private key.
+   * This is called from the UI after the user imports their JSON file.
+   */
+  async loadWallet(privateKey: string): Promise<void> {
+    const context = '[EthersWalletConnector:loadWallet]'
+    LoggerInstance.log(`${context} Attempting to load wallet.`)
+
+    try {
+      if (!privateKey.startsWith('0x')) {
+        privateKey = `0x${privateKey}`
+      }
+
+      // Use the first chain's RPC URL to create the provider for the wallet
+      const chainId = this.chains[0].id // TODO add option to configure default chain / check for last chain connected
+      const config = getOceanConfig(chainId)
+      this.#provider = new ethers.providers.JsonRpcProvider(config.nodeUri)
+
+      this.#wallet = new ethers.Wallet(privateKey, this.#provider)
+      const address = await this.#wallet.getAddress()
+
+      LoggerInstance.log(
+        `${context} Wallet loaded successfully for address: ${address}`
+      )
+
+      // Emit a 'change' event to notify wagmi of the new account
+      this.emit('change', {
+        account: await this.getAccount()
+      })
+    } catch (error) {
+      LoggerInstance.error(`${context} Failed to load wallet.`, error)
+      throw new Error('Failed to parse private key or initialize wallet.')
+    }
+  }
+
+  async connect() {
+    const context = '[EthersWalletConnector:connect]'
+    LoggerInstance.log(`${context} Attempting to connect.`)
+
+    if (!this.#wallet) {
+      LoggerInstance.warn(
+        `${context} Wallet not loaded. 'loadWallet' must be called first.`
+      )
+      throw new Error('Wallet not loaded. Call loadWallet(privateKey) first.')
+    }
+
+    try {
+      const account = await this.getAccount()
+      const provider = await this.getProvider()
+      const chainId = await this.getChainId()
+
+      LoggerInstance.log(
+        `${context} Connection successful for account: ${account}`
+      )
+
+      return {
+        account,
+        provider,
+        chain: {
+          id: chainId,
+          unsupported: this.isChainUnsupported(chainId)
+        }
+      }
+    } catch (error) {
+      LoggerInstance.error(`${context} Connection failed.`, error)
+      throw new Error('Could not establish connection.')
+    }
+  }
+
+  async disconnect() {
+    LoggerInstance.log(
+      '[EthersWalletConnector:disconnect] Disconnecting wallet.'
+    )
+    this.#wallet = undefined
+    this.emit('disconnect')
+  }
+
+  /**
+   * Re-creates the wallet instance with a provider for the new chain.
+   */
+  async switchChain(chainId: number): Promise<Chain> {
+    const context = '[EthersWalletConnector:switchChain]'
+    LoggerInstance.log(`${context} Attempting to switch to chainId: ${chainId}`)
+
+    if (!this.#wallet) {
+      throw new Error('Cannot switch chain. Wallet is not loaded.')
+    }
+
+    const chain = this.chains.find((chain) => chain.id === chainId)
+    if (!chain) {
+      LoggerInstance.warn(`${context} Unsupported chainId: ${chainId}`)
+      throw new Error(`Chain with id ${chainId} not supported.`)
+    }
+
+    try {
+      // 1. Get the private key from the existing wallet instance.
+      const { privateKey } = this.#wallet
+
+      // 2. Get the new chain's RPC configuration.
+      const config = getOceanConfig(chainId)
+      this.#provider = new ethers.providers.JsonRpcProvider(config.nodeUri)
+
+      // 3. Create a new wallet instance with the same key on the new provider.
+      this.#wallet = new ethers.Wallet(privateKey, this.#provider)
+
+      // 4. Notify wagmi that the chain has changed.
+      this.emit('change', { chain: { id: chainId, unsupported: false } })
+      LoggerInstance.log(
+        `${context} Successfully switched to chainId: ${chainId}`
+      )
+      return chain
+    } catch (error) {
+      LoggerInstance.error(`${context} Failed to switch chain.`, error)
+      throw new UserRejectedRequestError(error as Error)
+    }
+  }
+
+  async getChainId() {
+    const context = '[EthersWalletConnector:getChainId]'
+    try {
+      const provider = await this.getProvider()
+      const network = await provider.getNetwork()
+      return Number(network.chainId)
+    } catch (error) {
+      LoggerInstance.error(`${context} Failed to get chainId.`, error)
+      throw error
+    }
+  }
+
+  async getAccount(): Promise<`0x${string}`> {
+    const context = '[EthersWalletConnector:getAccount]'
+    if (!this.#wallet) {
+      throw new Error(`${context} Wallet not loaded.`)
+    }
+    return this.#wallet.address as `0x${string}`
+  }
+
+  getWallet(): ethers.Wallet {
+    const context = '[EthersWalletConnector:getWallet]'
+    if (!this.#wallet) {
+      LoggerInstance.warn(
+        `${context} Wallet is not loaded, returning undefined.`
+      )
+    }
+    return this.#wallet
+  }
+
+  async getProvider() {
+    const context = '[EthersWalletConnector:getProvider]'
+    try {
+      if (this.#wallet?.provider) {
+        return this.#wallet.provider
+      }
+      // Return a provider for the default chain if wallet is not yet connected
+      LoggerInstance.log(
+        `${context} Wallet not loaded, creating default provider.`
+      )
+      const chainId = this.chains[0].id
+      const config = getOceanConfig(chainId)
+      return new ethers.providers.JsonRpcProvider(config.nodeUri)
+    } catch (error) {
+      LoggerInstance.error(`${context} Failed to get provider.`, error)
+      throw error
+    }
+  }
+
+  async getSigner() {
+    const context = '[EthersWalletConnector:getSigner]'
+    if (!this.#wallet) {
+      throw new Error(`${context} Wallet not loaded.`)
+    }
+    return this.#wallet
+  }
+
+  async isAuthorized(): Promise<boolean> {
+    // A wallet is "authorized" if the instance exists.
+    return !!this.#wallet
+  }
+
+  // --- Event handlers ---
+
+  protected onAccountsChanged = (accounts: string[]) => {
+    // This wallet has a fixed account, so we can ignore this.
+  }
+
+  protected onChainChanged = (chainId: string | number) => {
+    // Do nothing
+  }
+
+  protected onDisconnect = (error: Error) => {
+    const context = '[EthersWalletConnector:onDisconnect]'
+    LoggerInstance.log(`${context} Disconnect event received.`)
+    if (error) {
+      LoggerInstance.error(`${context} Error on disconnect.`, error)
+    }
+    this.#wallet = undefined
+    this.emit('disconnect')
+  }
+}

--- a/src/@utils/wallet/index.ts
+++ b/src/@utils/wallet/index.ts
@@ -8,6 +8,7 @@ import { getSupportedChains } from './chains'
 import { chainIdsSupported } from '../../../app.config'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
 import { jsonRpcProvider } from 'wagmi/providers/jsonRpc'
+import { EthersWalletConnector } from './EthersWalletConnector'
 
 export async function getDummySigner(chainId: number): Promise<Signer> {
   if (typeof chainId !== 'number') {
@@ -44,6 +45,9 @@ export const wagmiClient = createClient({
   autoConnect: true,
   connectors: [
     new MetaMaskConnector({
+      chains
+    }),
+    new EthersWalletConnector({
       chains
     })
   ],

--- a/src/components/@shared/NetworkStatus/index.tsx
+++ b/src/components/@shared/NetworkStatus/index.tsx
@@ -52,22 +52,24 @@ export default function NetworkStatus({
     },
     [networkAlertConfig, chain]
   )
+  // TODO network status endpoint has been deprecated, enable once replacement is in place
+  // consider https://testnet.nexus.oasis.io/v1/pontusxtest/status for testnet
+  // https://testnet.nexus.oasis.io/v1/pontusxdev/status for devnet
+  // useEffect(() => {
+  //   if (!chain?.id) return
 
-  useEffect(() => {
-    if (!chain?.id) return
+  //   fetchNetworkStatus(chain?.id)
 
-    fetchNetworkStatus(chain?.id)
+  //   // init periodic refresh for network status
+  //   const networkStatusInterval = setInterval(
+  //     () => fetchNetworkStatus(chain?.id),
+  //     networkAlertConfig.refreshInterval
+  //   )
 
-    // init periodic refresh for network status
-    const networkStatusInterval = setInterval(
-      () => fetchNetworkStatus(chain?.id),
-      networkAlertConfig.refreshInterval
-    )
-
-    return () => {
-      clearInterval(networkStatusInterval)
-    }
-  }, [chain, fetchNetworkStatus])
+  //   return () => {
+  //     clearInterval(networkStatusInterval)
+  //   }
+  // }, [chain, fetchNetworkStatus])
 
   return (
     showNetworkAlert && (

--- a/src/components/@shared/Onboarding/Steps/Faucet.tsx
+++ b/src/components/@shared/Onboarding/Steps/Faucet.tsx
@@ -30,7 +30,7 @@ export default function Faucet(): ReactElement {
 
   const faucetTokenRequest = async () => {
     try {
-      const hashes = await requestTokens(accountId, signMessageData)
+      const hashes = await requestTokens(accountId, signMessageData, chain.id)
       toast.success(`Successfully requested test tokens: ${hashes.join(', ')}`)
       setCompleted(true)
     } catch (error) {

--- a/src/components/Faucet/index.tsx
+++ b/src/components/Faucet/index.tsx
@@ -87,7 +87,11 @@ const FaucetPage = (): ReactElement => {
   const faucetTokenRequest = useCallback(async () => {
     setIsRequestingTokens(true)
     try {
-      const hashes = await requestTokens(accountAddress, signMessageData)
+      const hashes = await requestTokens(
+        accountAddress,
+        signMessageData,
+        chain.id
+      )
       toast.success(`Successfully requested test tokens: ${hashes.join(', ')}`)
       setMessage(
         'Tokens successfully requested. It can take up to 30 seconds until tokens show up in your wallet.'

--- a/src/components/Header/UserPreferences/Automation/Details.tsx
+++ b/src/components/Header/UserPreferences/Automation/Details.tsx
@@ -65,10 +65,8 @@ export default function Details({
     autoWallet,
     autoWalletAddress,
     balance,
-    isAutomationEnabled,
     isLoading,
-    hasValidEncryptedWallet,
-    setIsAutomationEnabled
+    hasValidEncryptedWallet
   } = useAutomation()
 
   const { automationConfig } = useMarketMetadata().appConfig
@@ -95,21 +93,8 @@ export default function Details({
       {/* DESCRIPTION */}
       <strong className={styles.title}>Automation</strong>
       <div className={styles.help}>
-        Automate transactions using an imported wallet of your choice.
+        Automate transactions using an imported encrypted json wallet file.
       </div>
-
-      {/* EN-/DISABLE */}
-      {autoWallet?.address && (
-        <Button
-          style="primary"
-          onClick={() => {
-            setIsAutomationEnabled(!isAutomationEnabled)
-          }}
-          className={styles.toggleBtn}
-        >
-          {isAutomationEnabled ? 'Disable automation' : 'Enable automation'}
-        </Button>
-      )}
 
       {/* AUTOMATION ADDRESS */}
       {autoWalletAddress && (

--- a/src/components/Header/UserPreferences/Automation/Import.tsx
+++ b/src/components/Header/UserPreferences/Automation/Import.tsx
@@ -16,7 +16,12 @@ export default function Import(): ReactElement {
     try {
       const json = JSON.parse(content)
 
-      if (!json?.address || !json?.id || !json?.version || !json?.crypto)
+      if (
+        !json?.address ||
+        !json?.id ||
+        !json?.version ||
+        !(json?.crypto || json?.Crypto)
+      )
         return false
     } catch (e) {
       return false

--- a/src/components/Header/Wallet/Details.tsx
+++ b/src/components/Header/Wallet/Details.tsx
@@ -5,6 +5,7 @@ import Avatar from '@components/@shared/atoms/Avatar'
 import Bookmark from '@images/bookmark.svg'
 import { MenuLink } from '../Menu'
 import Button from '@components/@shared/atoms/Button'
+import { JSON_WALLET_CONNECTOR_ID } from '@utils/wallet/EthersWalletConnector'
 
 export default function Details(): ReactElement {
   const { address: accountId, connector: activeConnector } = useAccount()
@@ -38,15 +39,18 @@ export default function Details(): ReactElement {
             </span>
           </div>
           <div className={styles.actions}>
-            <Button
-              style="text"
-              size="small"
-              onClick={async () => {
-                connect()
-              }}
-            >
-              Switch Wallet
-            </Button>
+            {/* Switch Wallet disabled for json wallet */}
+            {activeConnector?.id !== JSON_WALLET_CONNECTOR_ID && (
+              <Button
+                style="text"
+                size="small"
+                onClick={async () => {
+                  connect()
+                }}
+              >
+                Switch Wallet
+              </Button>
+            )}
             <Button
               style="text"
               size="small"

--- a/src/components/Header/Wallet/index.tsx
+++ b/src/components/Header/Wallet/index.tsx
@@ -4,19 +4,23 @@ import Details from './Details'
 import Tooltip from '@shared/atoms/Tooltip'
 import styles from './index.module.css'
 import { useAccount } from 'wagmi'
+import { hideMetaMaskLogin } from 'app.config'
 
 export default function Wallet(): ReactElement {
   const { address: accountId } = useAccount()
 
   return (
-    <div className={styles.wallet}>
-      <Tooltip
-        content={<Details />}
-        trigger="click focus mouseenter"
-        disabled={!accountId}
-      >
-        <Account />
-      </Tooltip>
-    </div>
+    // hide MetaMask login button, but show address when connected via json wallet
+    (hideMetaMaskLogin !== 'true' || accountId) && (
+      <div className={styles.wallet}>
+        <Tooltip
+          content={<Details />}
+          trigger="click focus mouseenter"
+          disabled={!accountId}
+        >
+          <Account />
+        </Tooltip>
+      </div>
+    )
   )
 }


### PR DESCRIPTION
* feat: add new EthersWalletConnector to wagmi for automation-wallet

* refactor: use chain.id from wagmi for faucet request

* feat: add option to hide MetaMask login via NEXT_PUBLIC_HIDE_METAMASK_LOGIN

* fix: add compatibility with ethers v6 encrypted json format

* feat: hide switch wallet option for json wallet

* chore: disable fetchNetworkStatus until the endpoint is being replaced

* refactor: move JSON_WALLET_CONNECTOR_ID into EthersWalletConnector

* test: adjust wagmi mock to include Connector to pass tests

* refactor(connector): add robust logging and error handling to EthersWalletConnector

* chore: configure to use node 22 in package.json